### PR TITLE
Fixes issue #4731

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -259,3 +259,4 @@ Régis Behmo 2018/01/20
 Igor Kasianov, 2018/01/20
 Derek Harland, 2018/02/15
 Chris Mitchell, 2018/02/27
+Josue Balandrano Coronel, 2018/05/24

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -354,6 +354,17 @@ class help(Command):
 
 class report(Command):
     """Shows information useful to include in bug-reports."""
+    def __init__(self, *args, **kwargs):
+        """Custom initialization for report command
+
+        We need this custom initialization to make sure that
+        everything is loaded when running a report.
+        There has been some issues when printing Django's
+        settings because Django is not properly setup when 
+        running the report.
+        """
+        super(report, self).__init__(*args, **kwargs)
+        self.app.loader.import_default_modules()
 
     def run(self, *args, **kwargs):
         self.out(self.app.bugreport())


### PR DESCRIPTION
When running `celery -A proj report` the Celery app was being initialized but the default modules were not being imported for the `report` command.
The default modules are imported (as far as I can tell) only for `worker` and `shell`.
Most of the time, this is OK and no harm is done. But if the Celery app is pulling its config from a Django app there are some issues if there's a django specific function in one of the config's value.
The issue #4731 describes the problem when using `reverse_lazy` as one of the config values.
When the `report` command tries to "humanize" the Django config it cannot use `reverse_lazy` because that's dependent on Django's setup. Django is only setup within a Celery app when the default modules are loaded.

**Proposal :**
We might want to create two different `app` classes.
One for a regular Celery app and the other one for a Celery app that "needs" context.
This way we always setup that context (or a user-defined) context when initializing the app and we avoid future issues like this.
